### PR TITLE
Some systemd files don't like to be enabled by systemctl

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
                  [amazonica "0.3.21"]
                  [cheshire "5.4.0"]
                  [clj-time "0.9.0"]
-                 [clj-ssh "0.5.11"]
+                 [clj-ssh "0.5.12-SNAPSHOT"]
                  [org.slf4j/slf4j-log4j12 "1.7.7"]
                  [log4j/log4j "1.2.17" :exclusions [javax.mail/mail
                                                     javax.jms/jms


### PR DESCRIPTION
Added a filetype systemd-noinstall for things like paths etcs.  It's a hack.  I also fixed the project dependencies so that this will build with lein uberjar and via the docker container
