### PR TITLE
Added functions to get most recent coreos AMI.  

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,6 +15,7 @@
                  [amazonica "0.3.21"]
                  [cheshire "5.4.0"]
                  [clj-time "0.9.0"]
+                 [clj-http "2.0.0"]
                  [clj-ssh "0.5.12-SNAPSHOT"]
                  [org.slf4j/slf4j-log4j12 "1.7.7"]
                  [log4j/log4j "1.2.17" :exclusions [javax.mail/mail


### PR DESCRIPTION
- added clj-http to project and core.clj as a dependency
- added methods to retrieve most recent coreos ami via their API
- added the ability to use this most recent AMI by not specifying source-ami in the config.

_Note, I'm testing this currently_
