### PR TITLE
Thought for a quick hack to allow bastion-env.sh to be configured in mami.json

### DIFF
--- a/src/mami/core.clj
+++ b/src/mami/core.clj
@@ -297,7 +297,7 @@
 
             env-contents (if (:bastion-env config)
                            ;; XXX this is dangerous, quick, and highly configurable. (dan)
-                           (read-eval (:bastion-env config))
+                           (*read-eval* (:bastion-env config))
                            (str
                            "CUSTOMER_ID=" customer-id "\n"
                            "BASTION_ID=" bastion-id "\n"

--- a/src/mami/core.clj
+++ b/src/mami/core.clj
@@ -294,7 +294,11 @@
             nsqd-host (System/getenv "NSQD_HOST")
             bastion-ingress (System/getenv "ENABLE_BASTION_INGRESS")
             bastion-version (:bastion-version config)
-            env-contents (str
+
+            env-contents (if (:bastion-env config)
+                           ;; XXX this is dangerous, quick, and highly configurable. (dan)
+                           (read-eval (:bastion-env config))
+                           (str
                            "CUSTOMER_ID=" customer-id "\n"
                            "BASTION_ID=" bastion-id "\n"
                            "VPN_PASSWORD=" vpn-password "\n"
@@ -303,7 +307,7 @@
                            "DNS_SERVER=" dns-server "\n"
                            "NSQD_HOST=" nsqd-host "\n"
                            "ENABLE_BASTION_INGRESS=" bastion-ingress "\n"
-                           )]
+                           ))]
         (spit "bastion-env.sh" env-contents)
         (scp keypair username public-ip staging-dir {:from "bastion-env.sh"})
         (shell keypair username public-ip nil {:instructions [


### PR DESCRIPTION
Then could be specified with some fresh hell along the lines of the following untested snippet:

```
{
    "bastion-env":"(str",
               "\"BASTION_ID\" (System/getenv \"BASTION_VERSION\") \"\\n\"",
               "\"CUSTOMER_ID\" (System/getenv \"CUSTOMER_ID\") \"\\n\"",
               "\"VPN_PASSWORD=\" (System/getenv \"VPN_PASSWORD\") \"\\n\"",
               "\"BASTION_VERSION=\" (System/getenv \"BASTION_VERSION\") \"\\n\"",
               "\"VPN_REMOTE\" (System/getenv \"VPN_REMOTE\")  \"\\n\"",
               "\"DNS_SERVER\" (System/getenv \"DNS_SERVER\") \"\\n\"",
               "\"NSQD_HOST\"  (System/getenv \"NSQD_HOST\") \"\\n\"",
               "\"ENABLE_BASTION_INGRESS=false \\n\")",",
  }
```

But doing something like this would avoid a new commit to mami every time the bastion-env will change.  If it does again any time soon.
